### PR TITLE
Re-enable snakemake linter as issue fixed upstream

### DIFF
--- a/megalinter/descriptors/snakemake.megalinter-descriptor.yml
+++ b/megalinter/descriptors/snakemake.megalinter-descriptor.yml
@@ -11,8 +11,6 @@ linters:
   # Internal snakemake linter
   - linter_name: snakemake
     name: SNAKEMAKE_LINT
-    disabled: true
-    disabled_reason: Dependency datrie not maintained, and issue open in snakemake repo since july - https://github.com/snakemake/snakemake/issues/2970
     linter_url: https://snakemake.readthedocs.io/en/stable/
     linter_repo: https://github.com/snakemake/snakemake
     linter_banner_image_url: https://github.com/snakemake/snakemake/raw/6fcdc8a22db5522e232638bff16da9b50996eb45/images/biglogo.png

--- a/megalinter/descriptors/snakemake.megalinter-descriptor.yml
+++ b/megalinter/descriptors/snakemake.megalinter-descriptor.yml
@@ -23,7 +23,7 @@ linters:
       dockerfile:
         - |-
           # renovate: datasource=pypi depName=snakemake
-          ARG PIP_SNAKEMAKE_VERSION=9.3.4
+          ARG PIP_SNAKEMAKE_VERSION=9.3.5
       pip:
         - snakemake==${PIP_SNAKEMAKE_VERSION}
     ide:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. …
2. …
3. …

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/oxsecurity/megalinter/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
